### PR TITLE
Do not overwrite existing IConfiguration

### DIFF
--- a/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerExtensions.cs
+++ b/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Linq;
 
 namespace Autofac.Extensions.DependencyInjection.AzureFunctions
 {
@@ -18,12 +16,9 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
         /// <param name="hostBuilder">An instance of <see cref="IFunctionsHostBuilder"/>.</param>
         /// <param name="configure">The <see cref="ILoggingBuilder"/> configuration delegate.</param>
         /// <returns>The IFunctionsHostBuilder.</returns>
-        public static IFunctionsHostBuilder UseLogger(this IFunctionsHostBuilder hostBuilder, Action<ILoggingBuilder, IConfiguration> configure)
+        public static IFunctionsHostBuilder UseLogger(this IFunctionsHostBuilder hostBuilder, Action<ILoggingBuilder, IFunctionsHostBuilder> configure)
         {
-            var configuration = hostBuilder.Services.Where(x => x.ServiceType == typeof(IConfiguration)).SingleOrDefault()?.ImplementationInstance as IConfiguration;
-
-            hostBuilder.Services.AddLogging((config) => configure?.Invoke(config, configuration));
-
+            hostBuilder.Services.AddLogging((config) => configure?.Invoke(config, hostBuilder));
             return hostBuilder;
         }
     }

--- a/SampleAutofacFunction/Startup.cs
+++ b/SampleAutofacFunction/Startup.cs
@@ -14,15 +14,19 @@ namespace SampleAutofacFunction
         public override void Configure(IFunctionsHostBuilder builder)
         {
             builder
-                .UseAppSettings()
                 .UseLogger(ConfigureLogger)
                 .UseAutofacServiceProviderFactory(ConfigureContainer);
         }
 
-        private void ConfigureLogger(ILoggingBuilder builder, IConfiguration config)
+        private void ConfigureLogger(ILoggingBuilder builder, IFunctionsHostBuilder hostBuilder)
         {
-            builder.AddConfiguration(config.GetSection("Logging"));
+            builder.AddConfiguration(hostBuilder.GetContext().Configuration.GetSection("Logging"));
             builder.AddApplicationInsightsWebJobs();
+        }
+
+        public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)
+        {
+            builder.UseAppSettings();
         }
 
         private void ConfigureContainer(ContainerBuilder builder)


### PR DESCRIPTION
host.json is read and used by the runtime.  Extension settings are applied at startup for things like queue times, etc.
```
  "extensions": {
    "queues": {
      "maxPollingInterval": "00:00:02",
      "visibilityTimeout": "00:00:30",
      "batchSize": 16,
      "maxDequeueCount": 5,
      "newBatchThreshold": 8
    }
  } 
```
However, when your code overwrites the IConfiguration all these settings get removed.  
This PR leverages an overload designed to alter the configuration by adding app settings.
Additionally, there are new extensions to assist when needing the environment name (like when setting up logging, etc).
Using context, was able to make useLogger not do a manual lookup in IServiceCollection

Once these are in place, you still get all the features you were intending on adding plus all the built in ones.  