### PR TITLE
Use correct interfaces to build host

### DIFF
--- a/Autofac.Extensions.DependencyInjection.AzureFunctions/AppSettingsExtensions.cs
+++ b/Autofac.Extensions.DependencyInjection.AzureFunctions/AppSettingsExtensions.cs
@@ -11,16 +11,17 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
     public static class AppSettingsExtensions
     {
         /// <summary>
-        /// Creates an <see cref="IConfiguration"/> instance and attaches to an `appsettings.json` file, also adding an `appsettings.{environment}.json` on top of it, if available, based on current ASPNETCORE_ENVIRONMENT environment variable.
+        /// Creates an <see cref="IConfiguration"/> instance and attaches to an `appsettings.json` file, also adding an `appsettings.{environment}.json` on top of it, if available, based on current AZURE_FUNCTIONS_ENVIRONMENT environment variable.
         /// </summary>
         /// <param name="builder">An instance of <see cref="IFunctionsConfigurationBuilder"/>.</param>
-        /// <returns>The IFunctionsHostBuilder.</returns>
-        public static IFunctionsConfigurationBuilder UseAppSettings(this IFunctionsConfigurationBuilder builder)
+        /// <param name="reloadOnChange">Whether the configuration should be reloaded on file change.</param>
+        /// <returns>The <see cref="IFunctionsConfigurationBuilder"/>.</returns>
+        public static IFunctionsConfigurationBuilder UseAppSettings(this IFunctionsConfigurationBuilder builder, bool reloadOnChange = false)
         {
             var context = builder.GetContext();
             builder.ConfigurationBuilder
-                .AddJsonFile(Path.Combine(context.ApplicationRootPath, "appsettings.json"), optional: true, reloadOnChange: false)
-                .AddJsonFile(Path.Combine(context.ApplicationRootPath, $"appsettings.{builder.GetCurrentEnvironmentName()}.json"), optional: true, reloadOnChange: false)
+                .AddJsonFile(Path.Combine(context.ApplicationRootPath, "appsettings.json"), optional: true, reloadOnChange: reloadOnChange)
+                .AddJsonFile(Path.Combine(context.ApplicationRootPath, $"appsettings.{builder.GetCurrentEnvironmentName()}.json"), optional: true, reloadOnChange: reloadOnChange)
                 .AddEnvironmentVariables();
 
             return builder;

--- a/Autofac.Extensions.DependencyInjection.AzureFunctions/AppSettingsExtensions.cs
+++ b/Autofac.Extensions.DependencyInjection.AzureFunctions/AppSettingsExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using System;
 using System.IO;
 
@@ -55,7 +56,8 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
             string environmentName = Environment.GetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT") ??
                                      Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ??
                                      Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ??
-                                     contextEnvironmentName ?? "Development";
+                                     contextEnvironmentName ??
+                                     EnvironmentName.Development;
             return environmentName;
         }
     }

--- a/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerExtensions.cs
+++ b/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
@@ -16,9 +17,11 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
         /// <param name="hostBuilder">An instance of <see cref="IFunctionsHostBuilder"/>.</param>
         /// <param name="configure">The <see cref="ILoggingBuilder"/> configuration delegate.</param>
         /// <returns>The IFunctionsHostBuilder.</returns>
-        public static IFunctionsHostBuilder UseLogger(this IFunctionsHostBuilder hostBuilder, Action<ILoggingBuilder, IFunctionsHostBuilder> configure)
+        public static IFunctionsHostBuilder UseLogger(this IFunctionsHostBuilder hostBuilder, Action<ILoggingBuilder, IConfiguration> configure)
         {
-            hostBuilder.Services.AddLogging((config) => configure?.Invoke(config, hostBuilder));
+            var configuration = hostBuilder.GetContext().Configuration;
+
+            hostBuilder.Services.AddLogging((config) => configure?.Invoke(config, configuration));
             return hostBuilder;
         }
     }

--- a/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerExtensions.cs
+++ b/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerExtensions.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Linq;
 
 namespace Autofac.Extensions.DependencyInjection.AzureFunctions
 {
@@ -18,12 +16,9 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
         /// <param name="hostBuilder">An instance of <see cref="IFunctionsHostBuilder"/>.</param>
         /// <param name="configure">The <see cref="ILoggingBuilder"/> configuration delegate.</param>
         /// <returns>The IFunctionsHostBuilder.</returns>
-        public static IFunctionsHostBuilder UseLogger(this IFunctionsHostBuilder hostBuilder, Action<ILoggingBuilder, IConfiguration> configure)
+        public static IFunctionsHostBuilder UseLogger(this IFunctionsHostBuilder hostBuilder, Action<ILoggingBuilder, IFunctionsHostBuilder> configure)
         {
-            var configuration = hostBuilder.Services.Where(x => x.ServiceType == typeof(IConfiguration)).SingleOrDefault()?.ImplementationInstance as IConfiguration;
-
-            hostBuilder.Services.AddLogging((config) => configure?.Invoke(config, configuration));
-
+            hostBuilder.Services.AddLogging((config) => configure?.Invoke(config, hostBuilder));
             return hostBuilder;
         }
     }

--- a/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerModule.cs
+++ b/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerModule.cs
@@ -6,7 +6,6 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
     {
         public const string functionNameParam = "functionName";
         public const string loggerFactoryParam = "loggerFactory";
-        public const string telemetryParam = "telemetry";
 
         protected override void Load(ContainerBuilder builder)
         {

--- a/SampleAutofacFunction/SampleAutofacFunction.csproj
+++ b/SampleAutofacFunction/SampleAutofacFunction.csproj
@@ -20,6 +20,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <DependentUpon>appsettings.json</DependentUpon>
     </None>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <DependentUpon>appsettings.json</DependentUpon>
+    </None>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/SampleAutofacFunction/Startup.cs
+++ b/SampleAutofacFunction/Startup.cs
@@ -21,9 +21,9 @@ namespace SampleAutofacFunction
                 .UseAutofacServiceProviderFactory(ConfigureContainer);
         }
 
-        private void ConfigureLogger(ILoggingBuilder builder, IConfiguration configuration)
+        private void ConfigureLogger(ILoggingBuilder builder, IConfiguration config)
         {
-            builder.AddConfiguration(configuration.GetSection("Logging"));
+            builder.AddConfiguration(config.GetSection("Logging"));
         }
 
         public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)

--- a/SampleAutofacFunction/Startup.cs
+++ b/SampleAutofacFunction/Startup.cs
@@ -14,15 +14,19 @@ namespace SampleAutofacFunction
         public override void Configure(IFunctionsHostBuilder builder)
         {
             builder
-                .UseAppSettings()
                 .UseLogger(ConfigureLogger)
                 .UseAutofacServiceProviderFactory(ConfigureContainer);
         }
 
-        private void ConfigureLogger(ILoggingBuilder builder, IConfiguration config)
+        private void ConfigureLogger(ILoggingBuilder builder, IFunctionsHostBuilder hostBuilder)
         {
-            builder.AddConfiguration(config.GetSection("Logging"));
+            builder.AddConfiguration(hostBuilder.GetContext().Configuration.GetSection("Logging"));
             builder.AddApplicationInsightsWebJobs();
+        }
+
+        public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)
+        {
+            builder.UseAppSettings();
         }
 
         private void ConfigureContainer(ContainerBuilder builder)

--- a/SampleAutofacFunction/Startup.cs
+++ b/SampleAutofacFunction/Startup.cs
@@ -3,6 +3,7 @@ using Autofac.Extensions.DependencyInjection.AzureFunctions;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using SampleAutofacFunction.Settings;
 
 [assembly: FunctionsStartup(typeof(SampleAutofacFunction.Startup))]
@@ -14,19 +15,23 @@ namespace SampleAutofacFunction
         public override void Configure(IFunctionsHostBuilder builder)
         {
             builder
+                // You can call UseLogger to change how logging is done on your app by code. 
                 .UseLogger(ConfigureLogger)
+                // This is the required call in order to use autofac in your azure functions app
                 .UseAutofacServiceProviderFactory(ConfigureContainer);
         }
 
-        private void ConfigureLogger(ILoggingBuilder builder, IFunctionsHostBuilder hostBuilder)
+        private void ConfigureLogger(ILoggingBuilder builder, IConfiguration configuration)
         {
-            builder.AddConfiguration(hostBuilder.GetContext().Configuration.GetSection("Logging"));
-            builder.AddApplicationInsightsWebJobs();
+            builder.AddConfiguration(configuration.GetSection("Logging"));
         }
 
         public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)
         {
-            builder.UseAppSettings();
+            // this is optional and will bind IConfiguration with appsettings.json in
+            // the container, like it is usually done in regular dotnet console and
+            // web applications.
+            builder.UseAppSettings(true);
         }
 
         private void ConfigureContainer(ContainerBuilder builder)
@@ -34,28 +39,37 @@ namespace SampleAutofacFunction
             builder
                 .Register(activator =>
                 {
-                    var mySettings = new MySettings();
+                    // Example on how to bind settings from appsettings.json
+                    // to a class instance
+                    var section = activator.Resolve<IConfiguration>().GetSection(nameof(MySettings));
 
-                    var config = activator.Resolve<IConfiguration>();
-                    config.GetSection(nameof(MySettings)).Bind(mySettings);
+                    var instance = section.Get<MySettings>();
 
-                    return mySettings;
+                    // If you expect IConfiguration to change (with reloadOnChange=true), use
+                    // token to rebind.
+                    ChangeToken.OnChange(
+                       () => section.GetReloadToken(),
+                       (state) => section.Bind(state),
+                       instance);
+
+                    return instance;
                 })
                 .AsSelf()
                 .SingleInstance();
 
+            // Register all functions that resides in a given namespace
+            // The function class itself will be created using autofac
             builder
                 .RegisterAssemblyTypes(typeof(Startup).Assembly)
                 .InNamespace("SampleAutofacFunction.Functions")
-                .AsSelf()
-                .InstancePerTriggerRequest();
+                .AsSelf() // Azure Functions core code resolves a function class by itself.
+                .InstancePerTriggerRequest(); // This will scope nested dependencies to each function execution
 
             builder
                 .RegisterAssemblyTypes(typeof(Startup).Assembly)
                 .InNamespace("SampleAutofacFunction.Services")
                 .AsImplementedInterfaces()
                 .InstancePerTriggerRequest();
-
 
         }
     }

--- a/SampleAutofacFunction/appsettings.Development.json
+++ b/SampleAutofacFunction/appsettings.Development.json
@@ -1,0 +1,6 @@
+﻿{
+    "MySettings": {
+        "Value1": "Value 1 from appsettings.Development.json",
+        "Value2": "Value 2 from appsettings.Development.json"
+    }
+}

--- a/SampleAutofacFunction/local.settings.json
+++ b/SampleAutofacFunction/local.settings.json
@@ -2,7 +2,6 @@
     "IsEncrypted": false,
     "Values": {
         "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-        "ASPNETCORE_ENVIRONMENT": "Production",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet"
     }
 }


### PR DESCRIPTION
Added documentation and syntax changes on top of https://github.com/waynebrantley/autofac-azurefunctions PR #16

**Possible breaking change**: Use correct interfaces to build up host `IConfiguration`. Please read sample `Startup.cs` to see how to use `UseAppSettings`.

**Possible breaking change**: Use correct `AZURE_FUNCTIONS_ENVIRONMENT` to determine your environment. It is `Production` by default on Azure servers, `Development` locally.  See https://github.com/azure/azure-functions-host/issues/6239
