### PR TITLE
Fix local telemetry client dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v2
+        with:
+           dotnet-version: '6.0.x' 
         
       - name: "Get Commit Date"
         uses: actions/github-script@0.3.0
@@ -53,7 +57,7 @@ jobs:
         run: nuget restore
 
       - name: Build
-        run: msbuild -p:Configuration="$BUILD_CONFIGURATION" -p:Platform="$BUILD_PLATFORM" -m -p:GeneratePackageOnBuild=true -p:OutDir=$PUBLISH_DIR -p:Version=$VERSION_NUMBER -p:AssemblyVersion=$VERSION_NUMBER -p:AssemblyInformationalVersion=$VERSION_NUMBER -p:PackageVersion=$PACKAGE_VERSION -p:GenerateProjectSpecificOutputFolder=true
+        run: dotnet build -p:Configuration="$BUILD_CONFIGURATION" -p:Platform="$BUILD_PLATFORM" -m -p:GeneratePackageOnBuild=true -p:OutDir=$PUBLISH_DIR -p:Version=$VERSION_NUMBER -p:AssemblyVersion=$VERSION_NUMBER -p:AssemblyInformationalVersion=$VERSION_NUMBER -p:PackageVersion=$PACKAGE_VERSION -p:GenerateProjectSpecificOutputFolder=true
 
       - uses: actions/upload-artifact@v2
         name: Upload artifact

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-azurefunctions",
+    "ms-dotnettools.csharp"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to .NET Functions",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:azureFunctions.pickProcess}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "azureFunctions.deploySubpath": "SampleAutofacFunction/bin/Release/netcoreapp3.1/publish",
+    "azureFunctions.projectLanguage": "C#",
+    "azureFunctions.projectRuntime": "~3",
+    "debug.internalConsoleOptions": "neverOpen",
+    "azureFunctions.preDeployTask": "publish (functions)"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,81 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "clean (functions)",
+			"command": "dotnet",
+			"args": [
+				"clean",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"problemMatcher": "$msCompile",
+			"options": {
+				"cwd": "${workspaceFolder}/SampleAutofacFunction"
+			}
+		},
+		{
+			"label": "build (functions)",
+			"command": "dotnet",
+			"args": [
+				"build",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"dependsOn": "clean (functions)",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": "$msCompile",
+			"options": {
+				"cwd": "${workspaceFolder}/SampleAutofacFunction"
+			}
+		},
+		{
+			"label": "clean release (functions)",
+			"command": "dotnet",
+			"args": [
+				"clean",
+				"--configuration",
+				"Release",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"problemMatcher": "$msCompile",
+			"options": {
+				"cwd": "${workspaceFolder}/SampleAutofacFunction"
+			}
+		},
+		{
+			"label": "publish (functions)",
+			"command": "dotnet",
+			"args": [
+				"publish",
+				"--configuration",
+				"Release",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"dependsOn": "clean release (functions)",
+			"problemMatcher": "$msCompile",
+			"options": {
+				"cwd": "${workspaceFolder}/SampleAutofacFunction"
+			}
+		},
+		{
+			"type": "func",
+			"dependsOn": "build (functions)",
+			"options": {
+				"cwd": "${workspaceFolder}/SampleAutofacFunction/bin/Debug/netcoreapp3.1"
+			},
+			"command": "host start",
+			"isBackground": true,
+			"problemMatcher": "$func-dotnet-watch"
+		}
+	]
+}

--- a/Autofac.Extensions.DependencyInjection.AzureFunctions/Autofac.Extensions.DependencyInjection.AzureFunctions.csproj
+++ b/Autofac.Extensions.DependencyInjection.AzureFunctions/Autofac.Extensions.DependencyInjection.AzureFunctions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <VersionPrefix>6.0.0</VersionPrefix>
     <Description>Autofac implementation of the dependency injection factory for Azure Functions.</Description>
-    <Copyright>Copyright © 2020 Marcos Almeida Jr</Copyright>
+    <Copyright>Copyright © 2022 Marcos Almeida Jr</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralResourcesLanguage>en-US</NeutralResourcesLanguage>
@@ -26,11 +26,11 @@
     <Product>Autofac</Product>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(OutDir)/$(AssemblyName)</PackageOutputPath>
-    <PackageVersion>6.0.0</PackageVersion>
+    <PackageVersion>7.2.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
   </ItemGroup>
 

--- a/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerModule.cs
+++ b/Autofac.Extensions.DependencyInjection.AzureFunctions/LoggerModule.cs
@@ -7,6 +7,7 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
         public const string functionNameParam = "functionName";
         public const string loggerFactoryParam = "loggerFactory";
 
+
         protected override void Load(ContainerBuilder builder)
         {
             builder
@@ -17,6 +18,7 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
                     return factory;
                 })
                 .AsSelf()
+                .ExternallyOwned()
                 .SingleInstance();
 
             builder
@@ -29,6 +31,7 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
                 })
                 .AsSelf()
                 .InstancePerTriggerRequest();
+
 
         }
     }

--- a/Autofac.Extensions.DependencyInjection.AzureFunctions/Scopes.cs
+++ b/Autofac.Extensions.DependencyInjection.AzureFunctions/Scopes.cs
@@ -1,6 +1,6 @@
-﻿using Autofac.Builder;
-using System;
+﻿using System;
 using System.Linq;
+using Autofac.Builder;
 
 namespace Autofac.Extensions.DependencyInjection.AzureFunctions
 {
@@ -12,7 +12,7 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
         /// <summary>
         /// Represents the scope of a function trigger request.
         /// </summary>
-        public const string RootLifetimeScopeTag = "AutofacFunctionsScope";
+        public const string LifetimeScopeTag = "AutofacFunctionsScope";
 
         /// <summary>
         /// Share one instance of the component within the context of a single
@@ -32,7 +32,7 @@ namespace Autofac.Extensions.DependencyInjection.AzureFunctions
             if (registration == null)
                 throw new ArgumentNullException(nameof(registration));
 
-            var tags = new[] { Scopes.RootLifetimeScopeTag }.Concat(lifetimeScopeTags).ToArray();
+            var tags = new[] { Scopes.LifetimeScopeTag }.Concat(lifetimeScopeTags).ToArray();
             return registration.InstancePerMatchingLifetimeScope(tags);
         }
 

--- a/SampleAutofacFunction/Functions/Function3.cs
+++ b/SampleAutofacFunction/Functions/Function3.cs
@@ -1,0 +1,41 @@
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using SampleAutofacFunction.Services;
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace SampleAutofacFunction.Functions
+{
+    public class Function3 : IDisposable
+    {
+        private readonly IService1 _service1;
+        private readonly ILogger _logger;
+        private readonly Guid _id = Guid.NewGuid();
+
+        public Function3(IService1 service1, ILogger logger)
+        {
+            _service1 = service1;
+            _logger = logger;
+            _logger.LogWarning($"Creating {this}");
+        }
+
+        public void Dispose()
+        {
+            _logger.LogWarning($"Disposing {this}");
+        }
+
+        [FunctionName(nameof(Function3))]
+        public async Task Run([TimerTrigger("0 */5 * * * *", RunOnStartup = true)] TimerInfo timer)
+        {
+            await Task.Delay(2000);
+            Activity.Current.AddTag("Test", "Hello World");
+            _logger.LogInformation($"C# Timer trigger function processed.");
+        }
+
+        public override string ToString()
+        {
+            return $"{_id} ({nameof(Function1)})";
+        }
+    }
+}

--- a/SampleAutofacFunction/SampleAutofacFunction.csproj
+++ b/SampleAutofacFunction/SampleAutofacFunction.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/SampleAutofacFunction/SampleAutofacFunction.csproj
+++ b/SampleAutofacFunction/SampleAutofacFunction.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.0" />
   </ItemGroup>

--- a/SampleAutofacFunction/SampleAutofacFunction.csproj
+++ b/SampleAutofacFunction/SampleAutofacFunction.csproj
@@ -1,13 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.4" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.27" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.33" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Autofac.Extensions.DependencyInjection.AzureFunctions\Autofac.Extensions.DependencyInjection.AzureFunctions.csproj" />


### PR DESCRIPTION
Add support for calling the host Telemetry Client as it is supposed to work with the native Azure Function DI.